### PR TITLE
remove filter of touch-area events

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Usage
 
 ```nim
-requires "https://github.com/Quamolit/json-paint.nim#v0.0.12"
+requires "https://github.com/Quamolit/json-paint.nim#v0.0.16"
 ```
 
 ```nim

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ ops: [
   ['curve-to', [1, 2], [3, 4], [5, 6]],
   ['relative-curve-to', [1, 2], [3, 4], [5, 6]],
   ['arc', [1, 2], 1, [0, 6.28], false],
-  ['close-path']
+  ['new-path'],
+  ['close-path'],
 ]
 ```
 
@@ -135,7 +136,6 @@ data: Data # JSON
 x: 1
 y: 1
 radius: 20
-events: ["mouse-down", "mouse-up", "mouse-move"]
 ```
 
 ### Events

--- a/json_paint.nimble
+++ b/json_paint.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.0.14"
+version       = "0.0.15"
 author        = "jiyinyiyong"
 description   = "JSON DSL for canvas rendering"
 license       = "MIT"

--- a/json_paint.nimble
+++ b/json_paint.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.0.15"
+version       = "0.0.16"
 author        = "jiyinyiyong"
 description   = "JSON DSL for canvas rendering"
 license       = "MIT"

--- a/json_paint.nimble
+++ b/json_paint.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.0.16"
+version       = "0.0.17"
 author        = "jiyinyiyong"
 description   = "JSON DSL for canvas rendering"
 license       = "MIT"

--- a/src/json_paint.nim
+++ b/src/json_paint.nim
@@ -52,6 +52,7 @@ proc renderCanvas*(tree: JsonNode) =
   let base = TreeContext(x: 0, y: 0)
   resetTouchStack()
   ctx.processJsonTree(tree, base)
+  ctx.destroy()
 
   # cairo surface -> sdl serface -> sdl texture -> copy to render
   var dataPtr = surface.getData()

--- a/src/json_paint.nim
+++ b/src/json_paint.nim
@@ -60,6 +60,7 @@ proc renderCanvas*(tree: JsonNode) =
   let mainTexture = renderer.createTextureFromSurface(mainSurface)
   renderer.copy(mainTexture, nil, nil)
   renderer.present()
+  mainTexture.destroy()
 
 proc takeCanvasEvents*(handleEvent: proc(e: JsonNode):void) =
   var event: sdl2.Event

--- a/src/json_paint/shape_renderer.nim
+++ b/src/json_paint/shape_renderer.nim
@@ -141,7 +141,7 @@ proc renderText(ctx: ptr Context, tree: JsonNode, base: TreeContext) =
   var extents: TextExtents
   ctx.textExtents text.cstring, addr extents
   var realX = x - extents.xBearing
-  case text
+  case align
   of "center":
     realX = x - extents.width / 2 - extents.xBearing
   of "right":
@@ -149,7 +149,7 @@ proc renderText(ctx: ptr Context, tree: JsonNode, base: TreeContext) =
   of "left":
     discard
   else:
-    echo "unknown text align value: ", text
+    echo "WARNING: unknown align value " & align & ", expects left, center, right"
   let realY = y - extents.height / 2 - extents.yBearing
   ctx.moveTo realX, realY
   ctx.showText text

--- a/src/json_paint/shape_renderer.nim
+++ b/src/json_paint/shape_renderer.nim
@@ -146,8 +146,10 @@ proc renderText(ctx: ptr Context, tree: JsonNode, base: TreeContext) =
     realX = x - extents.width / 2 - extents.xBearing
   of "right":
     realX = x - extents.width - extents.xBearing
-  else:
+  of "left":
     discard
+  else:
+    echo "unknown text align value: ", text
   let realY = y - extents.height / 2 - extents.yBearing
   ctx.moveTo realX, realY
   ctx.showText text
@@ -218,6 +220,8 @@ proc callOps(ctx: ptr Context, tree: JsonNode, base: TreeContext) =
       ctx.rectangle point.x + base.x, point.y + base.y, size.x, size.y
     of "close-path":
       ctx.closePath()
+    of "new-path":
+      ctx.newPath()
     else:
       echo "WARNING: unknown op type: ", opType
 

--- a/src/json_paint/touches.nim
+++ b/src/json_paint/touches.nim
@@ -1,7 +1,6 @@
 
 import json
 import options
-import sets
 import math
 
 import ./error_util
@@ -25,7 +24,6 @@ type TouchArea* = object
   path*: JsonNode
   action*: JsonNode
   data*: JsonNode
-  events: HashSet[TouchEvent]
 
 var touchItemsStack: seq[TouchArea]
 
@@ -37,25 +35,9 @@ proc addTouchArea*(x: float, y: float, radius: float, tree: JsonNode) =
   if tree.contains("path").not: showError("Expects path field")
   if tree.contains("action").not: showError("Expects action field")
 
-  var events: HashSet[TouchEvent]
-  if tree.contains("events"):
-    for item in tree["events"].elems:
-      if item.kind == JString:
-        case item.getStr
-          of "mouse-down":
-            events.incl(touchDown)
-          of "mouse-up":
-            events.incl(touchUp)
-          of "mouse-move":
-            events.incl(touchMotion)
-          else:
-            showError("Unexpected event: " & item.getStr)
-      else:
-        echo "Expects string for event, got: ", item.kind
-
   touchItemsStack.add TouchArea(
     x: x, y: y, radius: radius,
-    path: tree["path"], events: events,
+    path: tree["path"],
     action: tree["action"],
     data: if tree.contains("data"): tree["data"] else: newJNull()
   )
@@ -64,9 +46,8 @@ proc findTouchArea*(x: cint, y: cint, eventKind: TouchEvent): Option[TouchArea] 
   let lastIdx = touchItemsStack.len - 1
   for idx in 0..lastIdx:
     let item = touchItemsStack[lastIdx - idx]
-    if item.events.contains(eventKind):
-      if (x.float - item.x).pow(2) + (y.float - item.y).pow(2) <= item.radius.pow(2):
-        return some(item)
+    if (x.float - item.x).pow(2) + (y.float - item.y).pow(2) <= item.radius.pow(2):
+      return some(item)
   return none(TouchArea)
 
 proc trackMousedownPoint*(x, y: int) =

--- a/tests/demo.nim
+++ b/tests/demo.nim
@@ -72,7 +72,6 @@ proc renderSomething() =
         "y": 80,
         "path": ["a", 1],
         "action": ":demo",
-        "events": ["mouse-down", "mouse-move"]
       },
     ]
   })

--- a/tests/demo.nim
+++ b/tests/demo.nim
@@ -50,7 +50,7 @@ proc renderSomething() =
       {
         "type": "text",
         "text": "this is a demo",
-        "align": "left",
+        "align": "center",
         "x": 40,
         "y": 40,
         "color": [140, 80, 76]


### PR DESCRIPTION
Current event handling logics manages events to a touch-area by path and action data, which made event filters buggy. So they are just removed.
